### PR TITLE
fix: pass unit timezone to all Envelope instances

### DIFF
--- a/src/Controller/DefaultController.php
+++ b/src/Controller/DefaultController.php
@@ -65,10 +65,10 @@ class DefaultController extends AbstractController
         ServicoServiceInterface $servicoService,
         FilaServiceInterface $filaService,
     ): Response {
-        $envelope = new Envelope();
         /** @var UsuarioInterface */
         $usuario  = $this->getUser();
         $unidade  = $usuario->getLotacao()->getUnidade();
+        $envelope = new Envelope(timezone: $unidade->getDateTimeZone());
 
         $data  = [];
         $param = $request->get('ids', '');
@@ -113,18 +113,16 @@ class DefaultController extends AbstractController
             throw $this->createNotFoundException();
         }
 
-        $envelope = new Envelope();
-
         /** @var UsuarioInterface */
         $usuario = $this->getUser();
         $unidade = $usuario->getLotacao()->getUnidade();
 
         $this->checkAtendimento($unidade, $atendimento, $translator);
 
-        $data = $atendimento->jsonSerialize();
-        $envelope->setData($data);
-
-        return $this->json($envelope);
+        return $this->json(new Envelope(
+            timezone: $unidade->getDateTimeZone(),
+            data: $atendimento->jsonSerialize(),
+        ));
     }
 
     /**
@@ -133,17 +131,17 @@ class DefaultController extends AbstractController
     #[Route("/buscar", name: "buscar", methods: ["GET"])]
     public function buscar(Request $request, AtendimentoServiceInterface $atendimentoService): Response
     {
-        $envelope = new Envelope();
-
         /** @var UsuarioInterface */
         $usuario = $this->getUser();
         $unidade = $usuario->getLotacao()->getUnidade();
         $numero = $request->get('numero');
 
         $atendimentos = $atendimentoService->buscaAtendimentos($unidade, $numero);
-        $envelope->setData($atendimentos);
 
-        return $this->json($envelope);
+        return $this->json(new Envelope(
+            timezone: $unidade->getDateTimeZone(),
+            data: $atendimentos,
+        ));
     }
 
     /**
@@ -162,11 +160,10 @@ class DefaultController extends AbstractController
             throw $this->createNotFoundException();
         }
 
-        $envelope = new Envelope();
-
         /** @var UsuarioInterface */
         $usuario = $this->getUser();
         $unidade = $usuario->getLotacao()->getUnidade();
+        $envelope = new Envelope(timezone: $unidade->getDateTimeZone());
 
         $this->checkAtendimento($unidade, $atendimento, $translator);
 
@@ -206,10 +203,10 @@ class DefaultController extends AbstractController
             throw $this->createNotFoundException();
         }
 
-        $envelope = new Envelope();
         /** @var UsuarioInterface */
         $usuario  = $this->getUser();
         $unidade  = $usuario->getLotacao()->getUnidade();
+        $envelope = new Envelope(timezone: $unidade->getDateTimeZone());
         $statuses = [AtendimentoServiceInterface::SENHA_CANCELADA, AtendimentoServiceInterface::NAO_COMPARECEU];
 
         if ($atendimento->getUnidade()->getId() !== $unidade->getId()) {
@@ -251,11 +248,10 @@ class DefaultController extends AbstractController
             throw $this->createNotFoundException();
         }
 
-        $envelope = new Envelope();
-
         /** @var UsuarioInterface */
         $usuario = $this->getUser();
         $unidade = $usuario->getLotacao()->getUnidade();
+        $envelope = new Envelope(timezone: $unidade->getDateTimeZone());
 
         $this->checkAtendimento($unidade, $atendimento, $translator);
         $atendimentoService->cancelar($atendimento, $usuario);


### PR DESCRIPTION
## Summary

- Pass `$unidade->getDateTimeZone()` to all `Envelope` constructors so the frontend receives the correct local timestamp and timezone name (`tz`) in every JSON response

## Test plan

- [x] Verify all monitor endpoints return the correct `tz` and `time` fields in the unit's configured timezone

🤖 Generated with [Claude Code](https://claude.com/claude-code)